### PR TITLE
fix(layout): prevent page-level horizontal scroll with wide tables

### DIFF
--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -93,7 +93,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <NavUser user={currentUser}/>
           </div>
         </header>
-        <main className="mx-auto flex w-full max-w-500 flex-1 flex-col gap-4 p-8">
+        <main className="mx-auto flex min-w-0 w-full max-w-500 flex-1 flex-col gap-4 overflow-x-hidden p-8">
           {children}
         </main>
       </SidebarInset>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -307,7 +307,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-2xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "relative flex min-w-0 w-full flex-1 flex-col overflow-x-hidden bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-2xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
This PR fixes an urgent UX bug where resizing table columns could trigger horizontal scrolling on the whole page.

## Problem
In table view, users could see two horizontal scrollbars at once:
- one for the table (expected)
- one for the entire page (unexpected)
This made navigation feel broken when working with wide tables.

## Solution
Constrain horizontal overflow at the page content containers so only the table handles horizontal scrolling.

## Changes
- Added `min-w-0` and `overflow-x-hidden` to the main shell content container.
- Added `min-w-0` and `overflow-x-hidden` to `SidebarInset`.
- Kept table-level horizontal scroll behavior unchanged.

## Testing
- Ran `pnpm lint` successfully.
- Verified the page no longer gets a horizontal scrollbar when table columns are expanded.
