### PR TITLE
style(table): remove shared table shadows

### DIFF
--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -6,10 +6,10 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement> & { containerClassName?: string }
 >(({ className, containerClassName, ...props }, ref) => (
-  <div className={cn("relative w-full overflow-auto", containerClassName)}>
+  <div className={cn("relative w-full overflow-auto shadow-none", containerClassName)}>
     <table
       ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
+      className={cn(className, "w-full caption-bottom text-sm shadow-none")}
       {...props}
     />
   </div>


### PR DESCRIPTION
## Summary
Remove default shadow from shared table component so table surfaces stay flat.

## Changes
- add shadow-none to shared table wrapper
- add shadow-none to shared table element

## Testing
- manually verified tickets table renders without shadow